### PR TITLE
Removes unneeded include

### DIFF
--- a/1-common-tasks/templates/class-template-sfinae.cpp
+++ b/1-common-tasks/templates/class-template-sfinae.cpp
@@ -1,7 +1,6 @@
 // Class template SFINAE
 
 #include <type_traits>
-#include <limits>
 
 template <typename T, typename Enable = void>
 class foo;
@@ -19,9 +18,9 @@ class foo<T, typename std::enable_if<std::is_floating_point<T>::value>::type>
 // 
 // We provide two partial specializations of the `foo` class template:
 // 
-// 1. The template on [9-11] will only be instantiated when `T` is an
+// 1. The template on [8-10] will only be instantiated when `T` is an
 //    integral type.
-// 2. The template on [13-15] will only be instantiated when `T` is a
+// 2. The template on [12-14] will only be instantiated when `T` is a
 //    floating point type.
 //    
 // This allows us to provide different implementations of the `foo`


### PR DESCRIPTION
The header <limits> is not needed here, since <type_traits> does the job with is_integral and is_floating_point. For those without access to a C++11 compiler, <limits> can be used in combination with Boost enable_if, in which case they need to check that std::numeric_limits<T>::is_integral be either true or false.
